### PR TITLE
Use current version of action in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ phpstan-linter:
         -   name: Check out code into the workspace
             uses: actions/checkout@v2
         -   name: Run php check code with reviewdog
-            uses: GeneaLabs/action-reviewdog-phpstan@1.0.0
+            uses: GeneaLabs/action-reviewdog-phpstan@1.1.2
             with:
                 github_token: '${{ github.token }}'
                 level: 'error'


### PR DESCRIPTION
Between Release 1.0.0 and Release 1.1.2 the action inputs `phpstan_level` and `fail_on_error` were added.

Simply copying the example from the README causes warnings in the action. In addition `phpstan_level` and `fail_on_error`  will not have any impact on the actions.

This PR simply bumps the version of the action used in this example to 1.1.2